### PR TITLE
Cross world item link

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -357,6 +357,7 @@ class MultiWorld():
                     return None, None
 
                 for item in shared_pool:
+                    # TODO: swap to max, pass out additional items
                     count = min(counters[player][item] for player in players_item_mapping.keys())
                     if count:
                         for player in players_item_mapping.keys():

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -266,6 +266,7 @@ class MultiWorld():
         replacement_prio = [False, True, None]
         for player in self.player_ids:
             for item_link in self.worlds[player].options.item_links.value:
+                # TODO: this logic is bug prone - remove the duplication
                 if item_link["name"] in item_links:
                     current_link = item_links[item_link["name"]]
                     current_link["replacement_item"][player] = item_link["replacement_item"]
@@ -289,7 +290,7 @@ class MultiWorld():
                         "replacement_item": {player: item_link["replacement_item"]},
                         "item_mapping": {player: item_mapping},
                         "item_pool": set(item_mapping.get(item, item) for item in item_link["item_pool"]),
-                        "item_pool_by_player": {player: item_link["item_pool"]},
+                        "item_pool_by_player": {player: set(item_mapping.get(item, item) for item in item_link["item_pool"])},
                         "exclude": set(item_mapping.get(item, item) for item in item_link.get("exclude", [])),
                         "game": self.game[player],
                         "local_items": set(item_mapping.get(item, item) for item in item_link.get("local_items", [])),
@@ -314,7 +315,6 @@ class MultiWorld():
             for item in pool:
                 if sum(item in item_link["item_pool_by_player"][player] for player in player_ids) <= 1:
                     single_player_items.add(item)
-            print("remove", single_player_items)
             pool -= single_player_items
             # Note that this isn't quite correct - if we end up with zero items in the pool for other players but not one,
             # we will still pointlessly item link

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -242,8 +242,8 @@ class MultiWorld():
         for player in self.player_ids:
             for item_link in self.worlds[player].options.item_links.value:
                 if item_link["name"] in item_links:
-                    if item_links[item_link["name"]]["game"] != self.game[player]:
-                        raise Exception(f"Cannot ItemLink across games. Link: {item_link['name']}")
+                    # if item_links[item_link["name"]]["game"] != self.game[player]:
+                    #     raise Exception(f"Cannot ItemLink across games. Link: {item_link['name']}")
                     current_link = item_links[item_link["name"]]
                     current_link["players"][player] = item_link["replacement_item"]
                     current_link["item_pool"] &= set(item_link["item_pool"])
@@ -348,16 +348,22 @@ class MultiWorld():
             for item in self.itempool:
                 count = common_item_count.get(item.player, {}).get(item.name, 0)
                 if count:
+                    player_item = AutoWorld.call_single(self, "create_item", item.player, item.name)
+
+
                     loc = Location(group_id, f"Item Link: {item.name} -> {self.player_name[item.player]} {count}",
                         None, region)
                     loc.access_rule = lambda state, item_name = item.name, group_id_ = group_id, count_ = count: \
                         state.has(item_name, group_id_, count_)
-
+                    print("Created", loc.name, item.name, player_item)
                     locations.append(loc)
-                    loc.place_locked_item(item)
+                    loc.place_locked_item(player_item)
                     common_item_count[item.player][item.name] -= 1
                 else:
                     new_itempool.append(item)
+                    if item.name == "Hookshot":
+                        print("item - ", item)
+
 
             itemcount = len(self.itempool)
             self.itempool = new_itempool

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -463,6 +463,7 @@ class MultiWorld():
                 self.random.shuffle(items_to_add)
                 self.itempool.extend(items_to_add[:itemcount - len(self.itempool)])
 
+            # TODO: at this point, punt out the used items into "item_mapping", for the slot data
     def secure(self):
         self.random = ThreadBarrierProxy(secrets.SystemRandom())
         self.is_race = True

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+import copy
 import functools
 import logging
 import random
@@ -201,7 +202,7 @@ class MultiWorld():
     def get_all_ids(self) -> Tuple[int, ...]:
         return self.player_ids + tuple(self.groups)
 
-    def add_group(self, name: str, game: str, players: AbstractSet[int] = frozenset()) -> Tuple[int, Group]:
+    def add_group(self, name: str, players: AbstractSet[int] = frozenset()) -> Tuple[int, Group]:
         """Create a group with name and return the assigned player ID and group.
         If a group of this name already exists, the set of players is extended instead of creating a new one."""
         from worlds import AutoWorld
@@ -222,7 +223,7 @@ class MultiWorld():
         self.worlds[new_id].remove = AutoWorld.World.remove.__get__(self.worlds[new_id])
         self.player_name[new_id] = name
 
-        new_group = self.groups[new_id] = Group(name=name, game=game, players=players,
+        new_group = self.groups[new_id] = Group(name=name, game="group_" + name, players=players,
                                                 world=self.worlds[new_id])
 
         return new_id, new_group
@@ -265,40 +266,43 @@ class MultiWorld():
         replacement_prio = [False, True, None]
         for player in self.player_ids:
             for item_link in self.worlds[player].options.item_links.value:
+                print("item link", player)
                 # TODO: this logic is bug prone - remove the duplication
-                if item_link["name"] in item_links:
-                    current_link = item_links[item_link["name"]]
-                    current_link["replacement_item"][player] = item_link["replacement_item"]
-                    current_item_mapping = item_link["item_mapping"]
-                    current_link["item_mapping"][player] = current_item_mapping
-                    current_link["item_pool_by_player"][player] = set(current_item_mapping.get(item, item) for item in item_link["item_pool"])
-                    current_link["item_pool"] |= current_link["item_pool_by_player"][player]
-                    current_link["exclude"] |= set(current_item_mapping.get(item, item) for item in item_link.get("exclude", []))
-                    # TODO: this is likely wrong, how is one supposed to use this??
-                    current_link["local_items"] &= set(current_item_mapping.get(item, item) for item in item_link.get("local_items", []))
-                    current_link["non_local_items"] &= set(current_item_mapping.get(item, item) for item in item_link.get("non_local_items", []))
-                    # TODO: not implemented for item mapping lol
-                    current_link["link_replacement"] = min(current_link["link_replacement"],
-                                                           replacement_prio.index(item_link["link_replacement"]))
-                else:
+                if item_link["name"] not in item_links:
                     if item_link["name"] in self.player_name.values():
                         raise Exception(f"Cannot name a ItemLink group the same as a player ({item_link['name']}) "
                                         f"({self.get_player_name(player)}).")
-                    item_mapping = item_link["item_mapping"]
                     item_links[item_link["name"]] = {
-                        "replacement_item": {player: item_link["replacement_item"]},
-                        "item_mapping": {player: item_mapping},
-                        "item_pool": set(item_mapping.get(item, item) for item in item_link["item_pool"]),
-                        "item_pool_by_player": {player: set(item_mapping.get(item, item) for item in item_link["item_pool"])},
-                        "exclude": set(item_mapping.get(item, item) for item in item_link.get("exclude", [])),
-                        "game": self.game[player],
-                        "local_items": set(item_mapping.get(item, item) for item in item_link.get("local_items", [])),
-                        "non_local_items": set(item_mapping.get(item, item) for item in item_link.get("non_local_items", [])),
-                        "link_replacement": replacement_prio.index(item_link["link_replacement"]),
+                        "replacement_item": {},
+                        "item_mapping": {},
+                        "item_pool": set(),
+                        "item_pool_by_player": {},
+                        "exclude": set(),
+                        "local_items": set(),
+                        "non_local_items": set(),
+                        "link_replacement": 999999999999999999,
                     }
 
-        for _name, item_link in item_links.items():
-            current_item_name_groups = AutoWorld.AutoWorldRegister.world_types[item_link["game"]].item_name_groups
+                current_link = item_links[item_link["name"]]
+                current_link["replacement_item"][player] = item_link["replacement_item"]
+                print(item_link["name"], current_link["replacement_item"])
+                current_item_mapping = item_link["item_mapping"]
+                # Initialize item mapping first from base of vanilla names, then overlaying mapping on top
+                # This probably shouldn't cause issues??
+                current_link["item_mapping"][player] = {key: key for key in self.worlds[player].item_name_to_id.keys()} | current_item_mapping
+                current_link["item_pool_by_player"][player] = set(current_item_mapping.get(item, item) for item in item_link["item_pool"])
+                current_link["item_pool"] |= current_link["item_pool_by_player"][player]
+                current_link["exclude"] |= set(current_item_mapping.get(item, item) for item in item_link.get("exclude", []))
+                # TODO: this is likely wrong, how is one supposed to use this??
+                current_link["local_items"] &= set(current_item_mapping.get(item, item) for item in item_link.get("local_items", []))
+                current_link["non_local_items"] &= set(current_item_mapping.get(item, item) for item in item_link.get("non_local_items", []))
+                # TODO: not implemented for item mapping lol
+                current_link["link_replacement"] = min(current_link["link_replacement"],
+                                                        replacement_prio.index(item_link["link_replacement"]))
+
+        for group_name, item_link in item_links.items():
+            # Uh TODO I broke this 
+            current_item_name_groups = {}#AutoWorld.AutoWorldRegister.world_types[item_link["game"]].item_name_groups
             player_ids = set(item_link["replacement_item"])
             pool = set()
             local_items = set()
@@ -328,10 +332,8 @@ class MultiWorld():
             item_link["local_items"] = local_items
             item_link["non_local_items"] = non_local_items
 
-        for group_name, item_link in item_links.items():
-            game = item_link["game"]
-            group_id, group = self.add_group(group_name, game, player_ids)
-
+            # ...
+            group_id, group = self.add_group(group_name, player_ids)
             group["item_pool"] = item_link["item_pool"]
             group["item_pool_by_player"] = item_link["item_pool_by_player"]
             group["replacement_items"] = item_link["replacement_item"]
@@ -355,7 +357,7 @@ class MultiWorld():
                     reverse_players_item_mapping[player] = {
                         v: k for k, v in item_mapping.items()
                     }
-                print(reverse_players_item_mapping)
+
                 for item in self.itempool:
                     if item.player in counters:
                         mapped_name = players_item_mapping[item.player].get(item.name, item.name)
@@ -372,7 +374,7 @@ class MultiWorld():
                     return None, None
 
                 additional_items = {player: {} for player in counters.keys()}
-                print(counters)
+
                 for item in shared_pool:
                     # Note: this needs to be recalculated per player instead - if they want to maximize or minimize
                     # the item count
@@ -385,10 +387,9 @@ class MultiWorld():
                         for player in players_item_mapping.keys():
                             if USE_MAX_INSTEAD:
                                 if count != counters[player][item]:
-                                    if item in player_pools[player]:
+                                    if item in player_pools[player]:            
                                         reversed_item_name = reverse_players_item_mapping[player].get(item, item)
                                         additional_items[player][reversed_item_name] = count - counters[player][item]
-                                        print("Added", additional_items[player][reversed_item_name], reversed_item_name, "for", player)
                             counters[player][item] = count
                     else:
                         for player in players_item_mapping.keys():
@@ -398,6 +399,8 @@ class MultiWorld():
             common_item_count, classifications, player_additional_items = find_common_pool(group["item_mapping"], group["item_pool"], group["item_pool_by_player"])
             if not common_item_count:
                 continue
+    
+            group["linked_items_by_player"] = copy.deepcopy(common_item_count)
 
             group_items = collections.defaultdict(list)
 
@@ -414,7 +417,7 @@ class MultiWorld():
                 for item, count in additional_items.items():
                     for i in range(count):
                         self.itempool.append(AutoWorld.call_single(self, "create_item", player, item))
-                        print("Created", player, item)
+                        # print("Created", player, item)
 
             region = Region(group["world"].origin_region_name, group_id, self, "ItemLink")
             self.regions.append(region)
@@ -435,7 +438,7 @@ class MultiWorld():
                         None, region)
                     loc.access_rule = lambda state, item_name = mapped_item_name, group_id_ = group_id, count_ = count: \
                         state.has(item_name, group_id_, count_)
-                    print("Created", loc.name, mapped_item_name, item.name, player_item)
+                    # print("Created", loc.name, mapped_item_name, item.name, player_item)
                     locations.append(loc)
                     loc.place_locked_item(player_item)
                     common_item_count[item.player][mapped_item_name] -= 1
@@ -464,6 +467,7 @@ class MultiWorld():
                 self.itempool.extend(items_to_add[:itemcount - len(self.itempool)])
 
             # TODO: at this point, punt out the used items into "item_mapping", for the slot data
+            # should be done now via group["linked_items_by_player"]?
     def secure(self):
         self.random = ThreadBarrierProxy(secrets.SystemRandom())
         self.is_race = True

--- a/Main.py
+++ b/Main.py
@@ -260,6 +260,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     games[slot] = multiworld.game[slot]
                     slot_info[slot] = NetUtils.NetworkSlot(group["name"], multiworld.game[slot], multiworld.player_types[slot],
                                                            group_members=sorted(group["players"]))
+                    for player in slot_info[slot].group_members:
+                        slot_info[player].item_mapping.update(group["item_mapping"][player])
                 precollected_items = {player: [item.code for item in world_precollected if type(item.code) == int]
                                       for player, world_precollected in multiworld.precollected_items.items()}
                 precollected_hints = {player: set() for player in range(1, multiworld.players + 1 + len(multiworld.groups))}
@@ -303,6 +305,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                 # Hydrate the data package for the group worlds
                 for group in multiworld.groups.values():
                     worlds.network_data_package["games"][group['world'].game] = group['world'].get_data_package_data()
+                    print(group['world'].game)
+                    print(group['world'].get_data_package_data())
 
                 # embedded data package
                 data_package = {

--- a/Main.py
+++ b/Main.py
@@ -300,6 +300,10 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                                   for player in multiworld.groups.get(location.item.player, {}).get("players", [])]):
                             precollect_hint(location, auto_status)
 
+                # Hydrate the data package for the group worlds
+                for group in multiworld.groups.values():
+                    worlds.network_data_package["games"][group['world'].game] = group['world'].get_data_package_data()
+
                 # embedded data package
                 data_package = {
                     game_world.game: worlds.network_data_package["games"][game_world.game]

--- a/Main.py
+++ b/Main.py
@@ -249,19 +249,24 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                 minimum_versions = {"server": AutoWorld.World.required_server_version, "clients": client_versions}
                 slot_info = {}
                 names = [[name for player, name in sorted(multiworld.player_name.items())]]
+
+                item_mapping = {}
+
+                for slot, group in multiworld.groups.items():
+                    games[slot] = multiworld.game[slot]
+                    slot_info[slot] = NetUtils.NetworkSlot(group["name"], multiworld.game[slot], multiworld.player_types[slot],
+                                                           group_members=sorted(group["players"]))
+                    for player in slot_info[slot].group_members:
+                        item_mapping[player] = item_mapping.get(player, {}) | {group["name"]: group["item_mapping"].get(player, {})}
+        
                 for slot in multiworld.player_ids:
                     player_world: AutoWorld.World = multiworld.worlds[slot]
                     minimum_versions["server"] = max(minimum_versions["server"], player_world.required_server_version)
                     client_versions[slot] = player_world.required_client_version
                     games[slot] = multiworld.game[slot]
                     slot_info[slot] = NetUtils.NetworkSlot(names[0][slot - 1], multiworld.game[slot],
-                                                           multiworld.player_types[slot])
-                for slot, group in multiworld.groups.items():
-                    games[slot] = multiworld.game[slot]
-                    slot_info[slot] = NetUtils.NetworkSlot(group["name"], multiworld.game[slot], multiworld.player_types[slot],
-                                                           group_members=sorted(group["players"]))
-                    for player in slot_info[slot].group_members:
-                        slot_info[player].item_mapping.update({group["name"]: group["item_mapping"][player]})
+                                                           multiworld.player_types[slot], (), item_mapping.get(slot, {}))
+
                 precollected_items = {player: [item.code for item in world_precollected if type(item.code) == int]
                                       for player, world_precollected in multiworld.precollected_items.items()}
                 precollected_hints = {player: set() for player in range(1, multiworld.players + 1 + len(multiworld.groups))}

--- a/Main.py
+++ b/Main.py
@@ -261,7 +261,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     slot_info[slot] = NetUtils.NetworkSlot(group["name"], multiworld.game[slot], multiworld.player_types[slot],
                                                            group_members=sorted(group["players"]))
                     for player in slot_info[slot].group_members:
-                        slot_info[player].item_mapping.update(group["item_mapping"][player])
+                        slot_info[player].item_mapping.update({group["name"]: group["item_mapping"][player]})
                 precollected_items = {player: [item.code for item in world_precollected if type(item.code) == int]
                                       for player, world_precollected in multiworld.precollected_items.items()}
                 precollected_hints = {player: set() for player in range(1, multiworld.players + 1 + len(multiworld.groups))}

--- a/Main.py
+++ b/Main.py
@@ -250,13 +250,12 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                 slot_info = {}
                 names = [[name for player, name in sorted(multiworld.player_name.items())]]
 
-                item_mapping = {}
+                all_item_mapping = {}
 
                 for slot, group in multiworld.groups.items():
                     games[slot] = multiworld.game[slot]
                     slot_info[slot] = NetUtils.NetworkSlot(group["name"], multiworld.game[slot], multiworld.player_types[slot],
                                                            group_members=sorted(group["players"]))
-                    print(group["name"], slot_info[slot].group_members)
                     for player in slot_info[slot].group_members:
                         item_mapping = group["item_mapping"][player]
                         reverse_item_mapping = {v: k for k, v in item_mapping.items()}
@@ -265,16 +264,15 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                             group_item_name: reverse_item_mapping[group_item_name]
                             for group_item_name, count in group["linked_items_by_player"].get(player, {}).items() if count and group_item_name in reverse_item_mapping
                         }
-                        print(player, group_item_to_player)
-                        item_mapping[player] = item_mapping.get(player, {}) | {group["name"]: group_item_to_player}
-        
+                        all_item_mapping[player] = all_item_mapping.get(player, {}) | {group["name"]: group_item_to_player}
                 for slot in multiworld.player_ids:
                     player_world: AutoWorld.World = multiworld.worlds[slot]
                     minimum_versions["server"] = max(minimum_versions["server"], player_world.required_server_version)
                     client_versions[slot] = player_world.required_client_version
                     games[slot] = multiworld.game[slot]
+                    print("set item_mapping", all_item_mapping.get(slot, {}))
                     slot_info[slot] = NetUtils.NetworkSlot(names[0][slot - 1], multiworld.game[slot],
-                                                           multiworld.player_types[slot], (), item_mapping.get(slot, {}))
+                                                           multiworld.player_types[slot], (), all_item_mapping.get(slot, {}))
 
                 precollected_items = {player: [item.code for item in world_precollected if type(item.code) == int]
                                       for player, world_precollected in multiworld.precollected_items.items()}

--- a/Main.py
+++ b/Main.py
@@ -256,8 +256,17 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     games[slot] = multiworld.game[slot]
                     slot_info[slot] = NetUtils.NetworkSlot(group["name"], multiworld.game[slot], multiworld.player_types[slot],
                                                            group_members=sorted(group["players"]))
+                    print(group["name"], slot_info[slot].group_members)
                     for player in slot_info[slot].group_members:
-                        item_mapping[player] = item_mapping.get(player, {}) | {group["name"]: group["item_mapping"].get(player, {})}
+                        item_mapping = group["item_mapping"][player]
+                        reverse_item_mapping = {v: k for k, v in item_mapping.items()}
+
+                        group_item_to_player = {
+                            group_item_name: reverse_item_mapping[group_item_name]
+                            for group_item_name, count in group["linked_items_by_player"].get(player, {}).items() if count and group_item_name in reverse_item_mapping
+                        }
+                        print(player, group_item_to_player)
+                        item_mapping[player] = item_mapping.get(player, {}) | {group["name"]: group_item_to_player}
         
                 for slot in multiworld.player_ids:
                     player_world: AutoWorld.World = multiworld.worlds[slot]

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1061,7 +1061,7 @@ def send_items_to(ctx: Context, team: int, target_slot: int, *items: NetworkItem
                 item_name = ctx.item_names[ctx.slot_info[target_slot].game][item.item]
                 # Reverse lookup the item name
                 mapped_item_name = item_name
-                for k, v in ctx.slot_info[target].item_mapping.items():
+                for k, v in ctx.slot_info[target].item_mapping.get(ctx.slot_info[target_slot].name, {}).items():
                     if v == item_name:
                         mapped_item_name = k
                         break

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1054,21 +1054,29 @@ def get_remaining(ctx: Context, team: int, slot: int) -> typing.List[typing.Tupl
 def send_items_to(ctx: Context, team: int, target_slot: int, *items: NetworkItem):
     for target in ctx.slot_set(target_slot):
         for item in items:
-            # TODO: not if target_slot == target
-            item_name = ctx.item_names[ctx.slot_info[target_slot].game][item.item]
-            # Get the new game
-            magic_game = ctx.slot_info[target].game 
-            # Translate the item
-            magic_item_id = ctx.item_names_for_game(magic_game).get(item_name)
+            mapped_item = item
+            if ctx.slot_info[target_slot].group_members and target_slot != target:
+                print(ctx.slot_info[target_slot].item_mapping)
+                # This should always be an item link item name
+                item_name = ctx.item_names[ctx.slot_info[target_slot].game][item.item]
+                # Reverse lookup the item name
+                mapped_item_name = item_name
+                for k, v in ctx.slot_info[target].item_mapping.items():
+                    if v == item_name:
+                        mapped_item_name = k
+                        break
+                print(item_name, mapped_item_name)
+                # Get the new game
+                mapped_game = ctx.slot_info[target].game 
+                # Translate the item
+                mapped_item_id = ctx.item_names_for_game(mapped_game).get(mapped_item_name)
 
-            if magic_item_id:
-                magic_item = NetworkItem(magic_item_id, item.location, item.player, item.flags)
-            else:
-                magic_item = item
+                if mapped_item_id:
+                    mapped_item = NetworkItem(mapped_item_id, item.location, item.player, item.flags)
+                
             if item.player != target_slot:
-                get_received_items(ctx, team, target, False).append(magic_item)
-                                # get the original item name
-            get_received_items(ctx, team, target, True).append(item)
+                get_received_items(ctx, team, target, False).append(mapped_item)
+            get_received_items(ctx, team, target, True).append(mapped_item)
 
 
 def register_location_checks(ctx: Context, team: int, slot: int, locations: typing.Iterable[int],

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -986,7 +986,9 @@ def get_status_string(ctx: Context, team: int, tag: str):
 
 
 def get_received_items(ctx: Context, team: int, player: int, remote_items: bool) -> typing.List[NetworkItem]:
-    return ctx.received_items.setdefault((team, player, remote_items), [])
+    items = ctx.received_items.setdefault((team, player, remote_items), [])
+    print("get_received_items", ctx.player_names[(team, player)], items)
+    return items
 
 
 def get_start_inventory(ctx: Context, player: int, remote_start_inventory: bool) -> typing.List[NetworkItem]:
@@ -1052,8 +1054,20 @@ def get_remaining(ctx: Context, team: int, slot: int) -> typing.List[typing.Tupl
 def send_items_to(ctx: Context, team: int, target_slot: int, *items: NetworkItem):
     for target in ctx.slot_set(target_slot):
         for item in items:
+            # TODO: not if target_slot == target
+            item_name = ctx.item_names[ctx.slot_info[target_slot].game][item.item]
+            # Get the new game
+            magic_game = ctx.slot_info[target].game 
+            # Translate the item
+            magic_item_id = ctx.item_names_for_game(magic_game).get(item_name)
+
+            if magic_item_id:
+                magic_item = NetworkItem(magic_item_id, item.location, item.player, item.flags)
+            else:
+                magic_item = item
             if item.player != target_slot:
-                get_received_items(ctx, team, target, False).append(item)
+                get_received_items(ctx, team, target, False).append(magic_item)
+                                # get the original item name
             get_received_items(ctx, team, target, True).append(item)
 
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -987,7 +987,6 @@ def get_status_string(ctx: Context, team: int, tag: str):
 
 def get_received_items(ctx: Context, team: int, player: int, remote_items: bool) -> typing.List[NetworkItem]:
     items = ctx.received_items.setdefault((team, player, remote_items), [])
-    print("get_received_items", ctx.player_names[(team, player)], items)
     return items
 
 
@@ -1052,20 +1051,22 @@ def get_remaining(ctx: Context, team: int, slot: int) -> typing.List[typing.Tupl
 
 
 def send_items_to(ctx: Context, team: int, target_slot: int, *items: NetworkItem):
+    print("send_items_to", team, target_slot)
+    print(ctx.slot_info)
     for target in ctx.slot_set(target_slot):
         for item in items:
             mapped_item = item
             if ctx.slot_info[target_slot].group_members and target_slot != target:
-                print(ctx.slot_info[target_slot].item_mapping)
                 # This should always be an item link item name
                 item_name = ctx.item_names[ctx.slot_info[target_slot].game][item.item]
+                group_name = ctx.slot_info[target_slot].name
                 # Reverse lookup the item name
                 mapped_item_name = item_name
-                for k, v in ctx.slot_info[target].item_mapping.get(ctx.slot_info[target_slot].name, {}).items():
-                    if v == item_name:
-                        mapped_item_name = k
-                        break
-                print(item_name, mapped_item_name)
+                if ctx.slot_info[target].item_mapping:
+                    for k, v in ctx.slot_info[target].item_mapping.get(group_name, {}).items():
+                        if v == item_name:
+                            mapped_item_name = k
+                            break
                 # Get the new game
                 mapped_game = ctx.slot_info[target].game 
                 # Translate the item

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -701,7 +701,7 @@ class Context:
     def slot_set(self, slot) -> typing.Set[int]:
         """Returns the slot IDs that concern that slot,
         as in expands groups out and returns back the input for solo."""
-        return self.groups.get(slot, {slot})
+        return set(self.groups.get(slot, {slot}))
 
     def _set_options(self, server_options: dict):
         for key, value in server_options.items():

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1061,16 +1061,23 @@ def send_items_to(ctx: Context, team: int, target_slot: int, *items: NetworkItem
                 # This should always be an item link item name
                 item_name = ctx.item_names[ctx.slot_info[target_slot].game][item.item]
                 
+                print(item_name, ctx.slot_info[target].item_mapping)
+
+                item_mapping = ctx.slot_info[target].item_mapping[ctx.slot_info[target_slot].name]
                 # If this player not participating in this item, skip
-                if item_name not in ctx.slot_info[target].item_mapping[target]:
+                if item_name not in item_mapping:
+                    print("skipped for ", target)
                     continue
 
                 # Translate the item
-                mapped_item_id = ctx.slot_info[target].item_mapping[item_name]
-
+                mapped_item_name = item_mapping[item_name]
+                # GDI forgot to write the actual ID :(
+                mapped_item_id = ctx.item_names_for_game(ctx.slot_info[target].game)[mapped_item_name]
+                print("translated to ", mapped_item_id)
                 if mapped_item_id:
                     mapped_item = NetworkItem(mapped_item_id, item.location, item.player, item.flags)
-                
+                print(mapped_item, ctx.slot_info[target].name)
+            print("will send ", mapped_item)
             if item.player != target_slot:
                 get_received_items(ctx, team, target, False).append(mapped_item)
             get_received_items(ctx, team, target, True).append(mapped_item)

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1053,24 +1053,20 @@ def get_remaining(ctx: Context, team: int, slot: int) -> typing.List[typing.Tupl
 def send_items_to(ctx: Context, team: int, target_slot: int, *items: NetworkItem):
     print("send_items_to", team, target_slot)
     print(ctx.slot_info)
+    is_group_send = ctx.slot_info[target_slot].group_members
     for target in ctx.slot_set(target_slot):
         for item in items:
             mapped_item = item
-            if ctx.slot_info[target_slot].group_members and target_slot != target:
+            if is_group_send and target_slot != target:
                 # This should always be an item link item name
                 item_name = ctx.item_names[ctx.slot_info[target_slot].game][item.item]
-                group_name = ctx.slot_info[target_slot].name
-                # Reverse lookup the item name
-                mapped_item_name = item_name
-                if ctx.slot_info[target].item_mapping:
-                    for k, v in ctx.slot_info[target].item_mapping.get(group_name, {}).items():
-                        if v == item_name:
-                            mapped_item_name = k
-                            break
-                # Get the new game
-                mapped_game = ctx.slot_info[target].game 
+                
+                # If this player not participating in this item, skip
+                if item_name not in ctx.slot_info[target].item_mapping[target]:
+                    continue
+
                 # Translate the item
-                mapped_item_id = ctx.item_names_for_game(mapped_game).get(mapped_item_name)
+                mapped_item_id = ctx.slot_info[target].item_mapping[item_name]
 
                 if mapped_item_id:
                     mapped_item = NetworkItem(mapped_item_id, item.location, item.player, item.flags)

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -83,7 +83,7 @@ class NetworkSlot(typing.NamedTuple):
     game: str
     type: SlotType
     group_members: typing.Union[typing.List[int], typing.Tuple] = ()  # only populated if type == group
-    item_mapping: dict[str, str] = dict() # only populated if slot in group and has item link maps set
+    item_mapping: dict[str, dict[str, str]] = dict() # only populated if slot in group and has item link maps set
 
 
 class NetworkItem(typing.NamedTuple):

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -83,6 +83,7 @@ class NetworkSlot(typing.NamedTuple):
     game: str
     type: SlotType
     group_members: typing.Union[typing.List[int], typing.Tuple] = ()  # only populated if type == group
+    item_mapping: dict[str, str] = dict() # only populated if slot in group and has item link maps set
 
 
 class NetworkItem(typing.NamedTuple):

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -83,7 +83,7 @@ class NetworkSlot(typing.NamedTuple):
     game: str
     type: SlotType
     group_members: typing.Union[typing.List[int], typing.Tuple] = ()  # only populated if type == group
-    item_mapping: dict[str, dict[str, str]] = dict() # only populated if slot in group and has item link maps set
+    item_mapping: typing.Optional[dict[str, dict[str, str]]] = None # only populated if slot in group and has item link maps set
 
 
 class NetworkItem(typing.NamedTuple):

--- a/Options.py
+++ b/Options.py
@@ -1366,6 +1366,7 @@ class ItemLinks(OptionList):
             Optional("local_items"): [And(str, len)],
             Optional("non_local_items"): [And(str, len)],
             Optional("link_replacement"): Or(None, bool),
+            Optional("item_mapping"): dict[str, str],
         }
     ])
 
@@ -1397,6 +1398,12 @@ class ItemLinks(OptionList):
                 raise Exception(f"You cannot have more than one link named {link['name']}.")
             existing_links.add(link["name"])
 
+            if "item_mapping" not in link:
+                link["item_mapping"] = dict()
+            else:
+                # TODO: verify unique values
+                # TODO: probably need to make sure that mappings aren't copied across either?
+                pass
             pool = self.verify_items(link["item_pool"], link["name"], "item_pool", world)
             local_items = set()
             non_local_items = set()

--- a/Options.py
+++ b/Options.py
@@ -1367,7 +1367,6 @@ class ItemLinks(OptionList):
             Optional("non_local_items"): [And(str, len)],
             Optional("link_replacement"): Or(None, bool),
             Optional("item_mapping"): dict[str, str],
-            Optional("additional_items"): dict[str, int],
         }
     ])
 
@@ -1402,10 +1401,6 @@ class ItemLinks(OptionList):
             if "item_mapping" not in link:
                 link["item_mapping"] = dict()            
             # TODO: verify unique values, valid items
-
-            if "additional_items" not in link:
-                link["additional_items"] = dict()
-            # TODO: verify valid items
 
             pool = self.verify_items(link["item_pool"], link["name"], "item_pool", world)
             local_items = set()

--- a/Options.py
+++ b/Options.py
@@ -1367,6 +1367,7 @@ class ItemLinks(OptionList):
             Optional("non_local_items"): [And(str, len)],
             Optional("link_replacement"): Or(None, bool),
             Optional("item_mapping"): dict[str, str],
+            Optional("additional_items"): dict[str, int],
         }
     ])
 
@@ -1399,11 +1400,13 @@ class ItemLinks(OptionList):
             existing_links.add(link["name"])
 
             if "item_mapping" not in link:
-                link["item_mapping"] = dict()
-            else:
-                # TODO: verify unique values
-                # TODO: probably need to make sure that mappings aren't copied across either?
-                pass
+                link["item_mapping"] = dict()            
+            # TODO: verify unique values, valid items
+
+            if "additional_items" not in link:
+                link["additional_items"] = dict()
+            # TODO: verify valid items
+
             pool = self.verify_items(link["item_pool"], link["name"], "item_pool", world)
             local_items = set()
             non_local_items = set()

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -648,6 +648,7 @@ class NetworkSlot(typing.NamedTuple):
    game: str
    type: SlotType
    group_members: typing.List[int] = []  # only populated if type == group
+   #TODO: docs
 ```
 
 ### Permission

--- a/worlds/alttp/Rom.py
+++ b/worlds/alttp/Rom.py
@@ -20,7 +20,7 @@ import concurrent.futures
 import bsdiff4
 from typing import Collection, Optional, List, SupportsIndex
 
-from BaseClasses import CollectionState, Region, Location, MultiWorld
+from BaseClasses import CollectionState, Region, Location, MultiWorld, GroupWorldItem
 from Utils import local_path, user_path, int16_as_bytes, int32_as_bytes, snes_to_pc, is_frozen, parse_yaml, read_snes_rom
 
 from .Shops import ShopType, ShopPriceType
@@ -799,6 +799,11 @@ def patch_rom(world: MultiWorld, rom: LocalRom, player: int, enemized: bool):
                 if not location.native_item:
                     if location.item.trap:
                         itemid = 0x5A  # Nothing, which disguises
+                    elif type(location.item) is GroupWorldItem and player in location.item.items_by_player:
+                        # for item link, if it's our item, use our sprite/item code
+                        # this doesn't really handle the is_dungeon_item cose below, but 
+                        # the remote item will do the right thing anyhow
+                        itemid = location.item.items_by_player[player].code
                     else:
                         itemid = get_nonnative_item_sprite(location.item.code)
                 # Keys in their native dungeon should use the orignal item code for keys

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -291,7 +291,9 @@ class LinksAwakeningWorld(World):
                     location.dungeon = r.dungeon_index
 
         # For now, special case first item
-        FORCE_START_ITEM = True
+        # We really should have merged the start item stuff by now, sad
+        # Disable this for item link :)
+        FORCE_START_ITEM = False
         if FORCE_START_ITEM:
             self.force_start_item()
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
1. Adds new `item_mapping` field to `item_link`, optional, but allows for fixing item names cross game
```LADX Example
  - name: everythinglol
    item_pool:
      - Everything
    replacement_item: null
    link_replacement: false
    item_mapping:
      # rename sword to "stabby" just because
      Progressive Sword: Stabby
      # map our ocarina to flute, as we are going to use LTTP items as the canonical name
      Ocarina: Flute
```
2. Removes check for disallowing cross world item links
3. Adds a bunch of logic to item links to handle item name mapping
4. When a group is created in gen, now makes an entirely new fresh world per group, rather than making a new dummy instance of an existing world. At the last minute, we push it into the datapackage. *this is a big kludge, should be more explicit here with world creation*. This world currently reserves 100k negative item ids per world, we could do something more complicated and more compact
5. When a group item is found, the id is mapped to the group item name, then reverse mapped to each player. This is done really poorly, we can make a reverse map up front.

## How was this tested?
Badly. I probably broke the local/nonlocal setting, I haven't worked through the logic of verifying mappings. If you make two items that map to the same thing, bad things probably happen.
OOT, SM, and some other things look for group games and try and do things with 'em. It's probably not needed, with the new `GroupWorld`.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/12146bb0-c0d1-440f-95bd-02a0ad2c825a)
![image](https://github.com/user-attachments/assets/4a9e0d1d-ba9e-47ad-8e3d-66825cc4a731)
